### PR TITLE
Fix exported public channel directory name for slack-export-viewer

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -165,9 +165,9 @@ def fetchPublicChannels(channels):
         return
 
     for channel in channels:
-        channelDir = channel['name'].encode('utf-8')
+        channelDir = channel['name']
         print("Fetching history for Public Channel: {0}".format(channelDir))
-        channelDir = channel['name'].encode('utf-8')
+        channelDir = channel['name']
         mkdir( channelDir )
         messages = getHistory(slack.conversations, channel['id'])
         parseMessages( channelDir, messages, 'channel')


### PR DESCRIPTION
Merge under the issue.
https://github.com/zach-snell/slack-export/issues/34